### PR TITLE
fix: explicit pki durations to match resulting objects

### DIFF
--- a/deploy/dnsimple/templates/pki.yaml
+++ b/deploy/dnsimple/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "dnsimple-webhook.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "dnsimple-webhook.selfSignedIssuer" . }}
   commonName: "ca.dnsimple-webhook.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "dnsimple-webhook.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "dnsimple-webhook.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
When using a GitOps deployment model, these resources are always
considered "out of sync", as the resulting Certificate object's
'duration' field also specifies minutes & seconds.

These changes are essentially a no-op, but match the object, for
GitOps compatability.