### PR TITLE
Fetch account ID from DNSimple API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ A [cert-manager][2] ACME DNS01 solver webhook for [DNSimple][1].
 
 ## Quickstart
 
-Take note of your DNSimple API token and account ID from the account settings in the automation tab. Run the following commands replacing the account ID, API token placeholders and email address:
+Take note of your DNSimple API token from the account settings in the automation tab. Run the following commands replacing the API token placeholders and email address:
 
 ```bash
 $ helm repo add neoskop https://charts.neoskop.dev
 $ helm install cert-manager-webhook-dnsimple \
     --namespace cert-manager \
     --dry-run \
-    --set dnsimple.account='<DNSIMPLE_ACCOUNT_ID>' \
     --set dnsimple.token='<DNSIMPLE_API_TOKEN>' \
     --set clusterIssuer.production.enabled=true \
     --set clusterIssuer.staging.enabled=true \
@@ -52,7 +51,6 @@ The Helm chart accepts the following values:
 
 | name                               | required | description                                     | default value                           |
 | ---------------------------------- | -------- | ----------------------------------------------- | --------------------------------------- |
-| `dnsimple.account`                 | ✔️       | DNSimple Account ID                             | _empty_                                 |
 | `dnsimple.token`                   | ✔️       | DNSimple API Token                              | _empty_                                 |
 | `clusterIssuer.email`              |          | LetsEncrypt Admin Email                         | `name@example.com`                      |
 | `clusterIssuer.production.enabled` |          | Create a production `ClusterIssuer`             | `false`                                 |

--- a/deploy/dnsimple/templates/production.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/production.cluster-issuer.yaml
@@ -18,7 +18,6 @@ spec:
     - dns01:
         webhook:
           config:
-            account: {{ .Values.dnsimple.account | quote }}
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.fullname" . }}

--- a/deploy/dnsimple/templates/staging.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/staging.cluster-issuer.yaml
@@ -18,7 +18,6 @@ spec:
     - dns01:
         webhook:
           config:
-            account: {{ .Values.dnsimple.account | quote }}
             tokenSecretRef:
               key: token
               name: {{ include "dnsimple-webhook.fullname" . }}

--- a/deploy/dnsimple/values.yaml
+++ b/deploy/dnsimple/values.yaml
@@ -12,7 +12,6 @@ certManager:
   serviceAccountName: cert-manager
 # logLevel: 3
 dnsimple:
-  account: ""
   token: ""
 clusterIssuer:
   email: name@example.com

--- a/testdata/dnsimple/.gitignore
+++ b/testdata/dnsimple/.gitignore
@@ -1,2 +1,1 @@
-config.json
 dnsimple-token.yaml

--- a/testdata/dnsimple/README.md
+++ b/testdata/dnsimple/README.md
@@ -1,10 +1,9 @@
 # Solver testdata directory
 
-Copy the example files removing the `.example` suffix:
+Copy the `dnsimple-token.yaml.example` example file removing the `.example` suffix:
 
 ```bash
-$ cp config.json{.example,}
 $ cp dnsimple-token.yaml{.example,}
 ```
 
-Replace the placeholders for the account ID in `config.json` and for the API token in `dnsimple-token.yaml`. Both can be found/generate in you DNSimple account settings in the automation tab.
+Replace the placeholders for the API token in `dnsimple-token.yaml`. The API token can be generated in your DNSimple account settings in the automation tab.

--- a/testdata/dnsimple/config.json
+++ b/testdata/dnsimple/config.json
@@ -2,6 +2,5 @@
     "tokenSecretRef": {
         "name": "dnsimple-token",
         "key": "token"
-    },
-    "account": "<Account-ID>"
+    }
 }


### PR DESCRIPTION
This means that users don't have to configure the account ID explicitly. This code is inspired by the DNSimple
provider in External-DNS.