### PR TITLE
Add support for using an existing token secret

### DIFF
--- a/deploy/dnsimple/templates/_helpers.tpl
+++ b/deploy/dnsimple/templates/_helpers.tpl
@@ -46,3 +46,7 @@ Create chart name and version as used by the chart label.
 {{- define "dnsimple-webhook.servingCertificate" -}}
 {{ printf "%s-webhook-tls" (include "dnsimple-webhook.fullname" .) }}
 {{- end -}}
+
+{{- define "dnsimple-webhook.tokenSecretName" -}}
+{{- default (include "dnsimple-webhook.fullname" .) (.Values.dnsimple.tokenSecretName) -}}
+{{- end -}}

--- a/deploy/dnsimple/templates/production.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/production.cluster-issuer.yaml
@@ -21,7 +21,7 @@ spec:
             account: {{ .Values.dnsimple.account | quote }}
             tokenSecretRef:
               key: token
-              name: {{ include "dnsimple-webhook.fullname" . }}
+              name: {{ include "dnsimple-webhook.tokenSecretName" . }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/templates/secret.yaml
+++ b/deploy/dnsimple/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if not .Values.dnsimple.existingTokenSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "dnsimple-webhook.fullname" . }}
+  name: {{ include "dnsimple-webhook.tokenSecretName" . }}
   labels:
     app: {{ include "dnsimple-webhook.name" . }}
     chart: {{ include "dnsimple-webhook.chart" . }}
@@ -10,6 +11,7 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.dnsimple.token | b64enc }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -23,7 +25,7 @@ metadata:
 rules:
 - apiGroups: [""] # indicates the core API group
   resources: ["secrets"]
-  resourceNames: ["{{ include "dnsimple-webhook.fullname" . }}"]
+  resourceNames: ["{{ include "dnsimple-webhook.tokenSecretName" . }}"]
   verbs: ["get", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/dnsimple/templates/staging.cluster-issuer.yaml
+++ b/deploy/dnsimple/templates/staging.cluster-issuer.yaml
@@ -21,7 +21,7 @@ spec:
             account: {{ .Values.dnsimple.account | quote }}
             tokenSecretRef:
               key: token
-              name: {{ include "dnsimple-webhook.fullname" . }}
+              name: {{ include "dnsimple-webhook.tokenSecretName" . }}
           groupName: {{ .Values.groupName }}
           solverName: dnsimple
 {{- end -}}

--- a/deploy/dnsimple/values.yaml
+++ b/deploy/dnsimple/values.yaml
@@ -14,6 +14,9 @@ certManager:
 dnsimple:
   account: ""
   token: ""
+
+  # existingTokenSecret: false
+  # tokenSecretName:
 clusterIssuer:
   email: name@example.com
   staging:


### PR DESCRIPTION
- Add variable dnsimple.existingTokenSecret to the Helm chart
  to support using an existing secret. This is useful e.g. in
  combination with https://github.com/bitnami-labs/sealed-secrets.
- Add variable dnsimple.tokenSecretName to support configuring the
  name of the token secret.