### PR TITLE
Add support for imagePullSecret

### DIFF
--- a/deploy/dnsimple/templates/deployment.yaml
+++ b/deploy/dnsimple/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.pullSecret }}
+          imagePullSecrets:
+            - name: {{ .Values.image.pullSecret }}
+          {{- end }}
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key

--- a/deploy/dnsimple/values.yaml
+++ b/deploy/dnsimple/values.yaml
@@ -24,6 +24,8 @@ image:
   repository: neoskop/cert-manager-webhook-dnsimple
   tag: 0.0.5
   pullPolicy: IfNotPresent
+  # pullSecret: "gcr"
+
 nameOverride: ""
 fullnameOverride: ""
 service:


### PR DESCRIPTION
Add variable image.pullSecret to Helm chart to support specifying an
image pull secret. This is mostly useful for people running an in-house
fork of cert-manager-webhook-dnsimple.