### PR TITLE
Support newer stable APIs in Helm chart

### DIFF
--- a/deploy/dnsimple/templates/apiservice.yaml
+++ b/deploy/dnsimple/templates/apiservice.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+{{- $APIRegistrationAPIVersion := ternary "apiregistration.k8s.io/v1" "apiregistration.k8s.io/v1beta1" (.Capabilities.APIVersions.Has "apiregistration.k8s.io/v1") -}}
+apiVersion: {{ $APIRegistrationAPIVersion }}
 kind: APIService
 metadata:
   name: v1alpha1.{{ .Values.groupName }}

--- a/deploy/dnsimple/templates/pki.yaml
+++ b/deploy/dnsimple/templates/pki.yaml
@@ -1,7 +1,8 @@
+{{- $CertManagerAPIVersion := ternary "cert-manager.io/v1" "cert-manager.io/v1alpha2" (.Capabilities.APIVersions.Has "cert-manager.io/v1") -}}
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ $CertManagerAPIVersion }}
 kind: Issuer
 metadata:
   name: {{ include "dnsimple-webhook.selfSignedIssuer" . }}
@@ -17,7 +18,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ $CertManagerAPIVersion }}
 kind: Certificate
 metadata:
   name: {{ include "dnsimple-webhook.rootCACertificate" . }}
@@ -38,7 +39,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ $CertManagerAPIVersion }}
 kind: Issuer
 metadata:
   name: {{ include "dnsimple-webhook.rootCAIssuer" . }}
@@ -55,7 +56,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ $CertManagerAPIVersion }}
 kind: Certificate
 metadata:
   name: {{ include "dnsimple-webhook.servingCertificate" . }}

--- a/deploy/dnsimple/templates/rbac.yaml
+++ b/deploy/dnsimple/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- $RBACAPIVersion := ternary "rbac.authorization.k8s.io/v1" "rbac.authorization.k8s.io/v1beta1" (.Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1") -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,7 +12,7 @@ metadata:
 # Grant the webhook permission to read the ConfigMap containing the Kubernetes
 # apiserver's requestheader-ca-certificate.
 # This ConfigMap is automatically created by the Kubernetes apiserver.
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ $RBACAPIVersion }}
 kind: RoleBinding
 metadata:
   name: {{ include "dnsimple-webhook.fullname" . }}:webhook-authentication-reader
@@ -33,7 +34,7 @@ subjects:
 ---
 # apiserver gets the auth-delegator role to delegate auth decisions to
 # the core apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ $RBACAPIVersion }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "dnsimple-webhook.fullname" . }}:auth-delegator
@@ -53,7 +54,7 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 # Grant cert-manager permission to validate using our apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ $RBACAPIVersion }}
 kind: ClusterRole
 metadata:
   name: {{ include "dnsimple-webhook.fullname" . }}:domain-solver
@@ -70,7 +71,7 @@ rules:
     verbs:
       - 'create'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: {{ $RBACAPIVersion }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "dnsimple-webhook.fullname" . }}:domain-solver


### PR DESCRIPTION
- Switch from apiregistration.k8s.io/v1beta1 to apiregistration.k8s.io/v1 where available
- Switch from rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1 where available
- Switch from cert-manager.io/v1alpha2 to cert-manager.io/v1 where available